### PR TITLE
File descriptor (FileInputStream) for Origin config files is not being closed properly

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/infrastructure/FileBackedRegistry.java
+++ b/components/proxy/src/main/java/com/hotels/styx/infrastructure/FileBackedRegistry.java
@@ -21,6 +21,7 @@ import com.hotels.styx.api.Resource;
 import org.slf4j.Logger;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.concurrent.CompletableFuture;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -53,7 +54,7 @@ public class FileBackedRegistry<T extends Identifiable> extends AbstractRegistry
 
     public String fileName() {
         return configurationFile.absolutePath();
-    };
+    }
 
     @Override
     public CompletableFuture<ReloadResult> reload() {
@@ -98,8 +99,8 @@ public class FileBackedRegistry<T extends Identifiable> extends AbstractRegistry
     }
 
     private byte[] readFile() {
-        try {
-            return toByteArray(configurationFile.inputStream());
+        try (InputStream configurationContent = configurationFile.inputStream()) {
+            return toByteArray(configurationContent);
         } catch (IOException e) {
             throw propagate(e);
         }


### PR DESCRIPTION
The method FileBackedRegistry.readFile() does not close the input stream for the configuration file provided. 

There's no test for this change. One could be implemented by extending FileResource and acquiring a lock when invoking "inputStream" (e.g., tryLock will throw an Exception if a lock has already being acquired for the file).

However, this issue seems to be a more general one and it would preferrable that, for instance, a static code analysis tool - such as findbugs - checked for this particular error in all the code.